### PR TITLE
Change URL regex to ignore tracking url data

### DIFF
--- a/src/tMsgText.py
+++ b/src/tMsgText.py
@@ -14,7 +14,7 @@ class tMsgText:
             logging.info(f"Allowed to reply to userID: {self.isfrom['id']}")
             # if message isn't "/start" from new telegram convo
             if self.message['text'] != "/start":
-                urlRegex: str = r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+'
+                urlRegex: str = r'http[s]?://(?:[a-zA-Z]|[0-9]|[./])+'
 
                 logging.debug(f"Parsing text against regex")
                 urls: list[str] = re.findall(urlRegex, self.message['text'])


### PR DESCRIPTION
URL regex now only matches on url text before a ?, to strip the Twitter tracking data from it prior to downloading