### PR TITLE
Add conversion of non-twitter URLs into twitter ones

### DIFF
--- a/src/tMsgText.py
+++ b/src/tMsgText.py
@@ -69,8 +69,13 @@ class tMsgText:
         logging.debug(f"Parsing text against regex")
         urls: list[str] = re.findall(self.urlRegex, toParse)
         logging.debug(f"Found {len(urls)} matches")
-        return urls
-    
+        
+        # Replace 'value' in http(s)://<value>.com with 'twitter'. This will
+        # attempt to convert URLs like vxtwitter.com, fxtwitter.com, x.com, etc
+        # into twitter.com URLs (assuming they're interchangeable)
+        convertedUrls: list[str] = list(map(lambda x: re.sub(pattern=r'(http[s]?://)([a-zA-Z]+|[0-9]+|[^?\s]+)(.com)', repl=r'\1twitter\3', string=x), urls))
+        logging.debug(f"Converted {len(convertedUrls)} matches into twitter.com format URLs")
+        return convertedUrls
 
     def downloadUrl(self, url: str) -> tuple[str, int]:
         logging.info(f"Attempting to gallery-dl download content from: {url}")

--- a/src/tests/test_tMsgText.py
+++ b/src/tests/test_tMsgText.py
@@ -16,8 +16,9 @@ class Test_regexParse(unittest.TestCase):
             ("https://twitter.com/testUser/status/1234567898765432125?s=12&t=123456789", "https://twitter.com/testUser/status/1234567898765432125"),
             ("https://twitter.com/test_User/status/1234567898765432126?s=12&t=123456789", "https://twitter.com/test_User/status/1234567898765432126"),
             ("https://twitter.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://twitter.com/test_User12345/status/1234567898765432127"),
-            ("https://vxtwitter.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://vxtwitter.com/test_User12345/status/1234567898765432127"),
-            ("https://fxtwitter.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://fxtwitter.com/test_User12345/status/1234567898765432127"),
+            ("https://vxtwitter.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://twitter.com/test_User12345/status/1234567898765432127"),
+            ("https://fxtwitter.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://twitter.com/test_User12345/status/1234567898765432127"),
+            ("https://x.com/test_User12345/status/1234567898765432127?s=12&t=123456789", "https://twitter.com/test_User12345/status/1234567898765432127"),
         ]
         for url in urls:
             msg = json.loads(f'{{"message_id": 1, "from": {{"id": 12345678, "is_bot": false, "first_name": "test_fName", "username": "test_username", "language_code": "en"}}, "chat": {{"id": 12345678, "first_name": "test_fName", "username": "test_username", "type": "private"}}, "date": 1234567890, "text": "{url[0]}"}}')


### PR DESCRIPTION
Changed so that any non-twitter URLs (x.com, vxtwitter.com, fxtwitter.com, etc) are converted to twitter.com ones

Changed tests to check this behaviour

To resolve #48