### PR TITLE
Add connection timeouts

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -7,7 +7,7 @@ from config import Config
 class bot:
     def __init__(self):
         self.msgOffset: int = 0
-        self.pollTimeout: int = 120
+        self.pollTimeout: int = 50
         logging.info(f"Using max long polling timeout of {self.pollTimeout} seconds")
 
     def getHelp(self):

--- a/src/tMsgSender.py
+++ b/src/tMsgSender.py
@@ -48,7 +48,10 @@ class tMsgSender:
         requestString = self.generateRequest(msgParams)
 
         try:
-            request: requests.Response = requests.get(requestString)
+            # Use both a connect and read timeout. Should establish a connection
+            # to Telegram within the connect timeout, but shouldn't consider the
+            # connection to have been broken until after the long polling duration
+            request: requests.Response = requests.get(requestString, timeout=(5, 50))
             # return True/False for a status code of 2XX, the status code itself and the response content
             return recievedData(request.ok, statusCode=request.status_code, content=request.content)
         except Exception as e:

--- a/src/tMsgSender.py
+++ b/src/tMsgSender.py
@@ -51,7 +51,7 @@ class tMsgSender:
             # Use both a connect and read timeout. Should establish a connection
             # to Telegram within the connect timeout, but shouldn't consider the
             # connection to have been broken until after the long polling duration
-            request: requests.Response = requests.get(requestString, timeout=(5, 50))
+            request: requests.Response = requests.get(requestString, timeout=(5, 60))
             # return True/False for a status code of 2XX, the status code itself and the response content
             return recievedData(request.ok, statusCode=request.status_code, content=request.content)
         except Exception as e:


### PR DESCRIPTION
Reduced the default long-polling duration from 120s to 50s, which appears to be the longest time Telegram will wait for.

Added connect and read timeouts, set to 5s and 60s respectively. This means the connection should timeout if it fails to contact Telegram within 5s, or connects but doesn't hear back from Telegram (regarding the long-polling) within 60s (bit of leeway over the 50s polling wait).

This should help recover the application if the connection to Telegram is broken (instead of waiting forever and needing a reboot to fix).